### PR TITLE
Use LABEL instead of MAINTAINER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:11-jre
-MAINTAINER Sindice LTD <info@siren.io>
+LABEL io.siren.avatica.maintainer="Sindice LTD <info@siren.io>"
 
 RUN useradd -m avatica
 RUN mkdir -p /home/avatica/server && \


### PR DESCRIPTION
VS Code tells me that MAINTAINER is deprecated....

https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

